### PR TITLE
Adjust sidebar mobile menu exit buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,7 +101,7 @@ body {
 }
 
 .hamburger.open {
-  right: 60%;
+  right: 3%;
   transition: .25s ease-in-out;
   z-index: 200;
 

--- a/src/components/SidebarMenu.js
+++ b/src/components/SidebarMenu.js
@@ -29,17 +29,18 @@ export default function SidebarMenu({ isSidebarOpen, setIsSidebarOpen }) {
 
         <div>
             {/* Mobile Sidebar */}
-            <div className={`fixed top-0 right-0 h-full bg-white text-black p-4 transform ${isSidebarOpen ? 'translate-x-0' : 'translate-x-full'} transition-transform duration-500 ease-in-out z-[60] w-3/5 text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl transition duration-700`}>
+            <div className={`fixed top-0 right-0 h-full bg-white text-black p-4 transform ${isSidebarOpen ? 'translate-x-0' : 'translate-x-full'} transition-transform duration-500 ease-in-out z-[60] w-3/5 text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl`}>
 
                 {/* Close Button */}
-                <div style={{ zIndex: '155' }}>
+                {/* <div style={{ zIndex: '155' }}>
                     <button
                         onClick={() => setIsSidebarOpen(false)}
-                        className="absolute top-0 right-0 m-4 text-lg"
+                        className="absolute top-4 right-4 text-lg z-0"
+                        style={{ zIndex: 155 }}
                     >
                         X
                     </button>
-                </div>
+                </div> */}
 
                 {/* Logo */}
                 <div className="flex justify-center items-center mb-4">
@@ -54,7 +55,7 @@ export default function SidebarMenu({ isSidebarOpen, setIsSidebarOpen }) {
 
                 <ul className="space-y-2">
                     <li><Link href="/" className="block px-4 py-2 hover:bg-green-800">Home</Link></li>
-                  
+
                     {/* Fencing Dropdown */}
                     <li className="relative">
                         <button onClick={() => setIsFencingDropdownOpen(!isFencingDropdownOpen)} className="hover:bg-green-700 p-2 rounded w-full text-left text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl">


### PR DESCRIPTION
Remove top right x on sidebar and make the hamburger button stand still when opening the sidebar menu to make the close button more visible